### PR TITLE
Provenance tag

### DIFF
--- a/helm/plater/templates/plater-deployment.yaml
+++ b/helm/plater/templates/plater-deployment.yaml
@@ -63,6 +63,8 @@ spec:
               value: "{{ .Values.app.gunicorn.worker_timeout }}"
             - name: NUM_WORKERS
               value: "{{ .Values.app.gunicorn.num_workers }}"
+            - name: PROVENANCE_TAG
+              value: "{{ .Values.datasetDesc.provenanceTag }}"
           volumeMounts:
             - mountPath: /home/plater/Plater/about.json
               name: {{ include "plater.fullname" . }}-config-files

--- a/helm/plater/values.yaml
+++ b/helm/plater/values.yaml
@@ -25,7 +25,7 @@ app:
     num_workers: 4
   port: 8080
   automatAddress: http://automat
-  bl_version: 1.6.0
+  bl_version: 1.8.2
   neo4j:
     httpPort: 7474
     boltPort: 7687
@@ -71,4 +71,5 @@ datasetDesc:
   dataseturl: ''
   generatorCode: ''
   neo4j_dump: ""
+  provenanceTag: "infores:automat.platersource"
   license: "" # link to terms of service


### PR DESCRIPTION
incorporating the provenance tag for trapi query graphs. 

associated values files are in the usual place and they have been updated to support provenance and the latest biolink model version..