### PR TITLE
adds liveliness and readiness probs to neo4j

### DIFF
--- a/helm/plater/templates/neo4j-deployment.yaml
+++ b/helm/plater/templates/neo4j-deployment.yaml
@@ -85,6 +85,12 @@ spec:
           - mountPath: /logs
             name: {{ include "plater.fullname" . }}-neo4jkp-pvc
             subPath: neo4j_logs
+          startupProbe:
+{{ toYaml .Values.neo4j.startupProbe | indent 12 }}
+          readinessProbe:
+{{ toYaml .Values.neo4j.readinessProbe | indent 12 }}
+          livenessProbe:
+{{ toYaml .Values.neo4j.livenessProbe | indent 12 }}
       restartPolicy: Always
       volumes:
         - name: {{ include "plater.fullname" . }}-scripts

--- a/helm/plater/values.yaml
+++ b/helm/plater/values.yaml
@@ -17,6 +17,36 @@ image:
 nameOverride: ""
 fullnameOverride: ""
 
+neo4j:
+  # Readiness probes will send a kill signal to the container if
+  # it fails enough times.  It's therefore very important
+  # that initialDelaySeconds give the cluster time to form, because
+  # if readiness probes start immediately after container start,
+  # they may end up not forming quickly enough and getting killed.
+  readinessProbe:
+    initialDelaySeconds: 30
+    failureThreshold: 3
+    timeoutSeconds: 2
+    periodSeconds: 10
+    tcpSocket:
+      port: 7687
+
+  livenessProbe:
+    initialDelaySeconds: 60
+    periodSeconds: 10
+    failureThreshold: 3
+    timeoutSeconds: 2
+    tcpSocket:
+      port: 7687
+
+  # Startup probes are used to know when a container application has started.
+  # If such a probe is configured, it disables liveness and readiness checks until it succeeds
+  startupProbe:
+    failureThreshold: 2000
+    periodSeconds: 25
+    tcpSocket:
+      port: 7687
+
 service:
   type: ClusterIP
 app:


### PR DESCRIPTION
Adds liveliness and ready ness probs to neo4j restarts will be triggered based on the number of failures specified 