### PR TITLE
Feature/strider health checks

### DIFF
--- a/helm/chemical-normalization/Readme.md
+++ b/helm/chemical-normalization/Readme.md
@@ -1,0 +1,65 @@
+ Helm Chart
+---
+> [Source code for Chemcialnormalization](https://github.com/TranslatorIIPrototypes/ChemNormalization)
+>
+> [Docker Image](https://hub.docker.com/repository/docker/renciorg/r3_chemnorm)
+
+
+### Introduction 
+
+This Chart can be used to install [Node normalization service](https://nodenormalization-sri.renci.org/docs).
+
+### Parameters
+
+| Parameter | Description | Default |
+| --------- | ----        | ----    | 
+| `redisImage.repository` | Redis  docker image  | `redis`
+| `redisImage.tag` |  Redis docker image tag | `latest`
+| `webserverImage.repository` |  Web server docker image  | `renciorg/r3_chemnorm`
+| `webserverImage.tag` | Web server docker tag  | `latest`
+| `redis.service.type` | Redis server kubernetes service type  | `ClusterIP`
+| `redis.port` | Redis server port | `6379`
+| `redis.resources.limits.memory` | Redis server memory limit  | `nil`
+| `redis.resources.requests.memory` | Redis server memory   | `nil`
+| `data_url` |  This will create an init container that downloads redis dump.rdb file before redis server starts. | `https://location.to/dump.rdb`
+| `redis.storage.size` |  Redis storage size  | `nil`
+| `redis.args` |  Redis server args | `['--save', '', '--stop-writes-on-bgsave-error', 'no']`
+| `web.replicaCount` | Web server replica count   | `1`
+| `web.service.type` | Web server kubernetes service type  | `ClusterIP`
+| `web.port` |  Web server port | `6380`
+| `ingress.host` | Ingress DNS host name   | `nil`
+| `ingress.class` | Ingress class  | `nil`
+ 
+
+### Installing 
+
+Note:  Any of the above parameters can be overridden using set argument. 
+```shell script
+<.../helm/r3>$ helm install  myrelease . 
+```
+
+### Uninstalling
+
+```shell script
+<.../helm/r3>$ helm uninstall myrelease
+```
+
+### Upgrading
+
+```shell script
+<.../helm/r3>$ helm upgrade --set web.port=80 myrelease . 
+```
+
+###Other deployment commands
+To render your chart without deploying:
+ 
+```shell script
+$ helm template --debug -f <values_file> myrelease .
+```
+
+
+To dry run your chart install: 
+```console
+$ helm install -f <values_file> --dry-run --debug myrelease .
+```
+

--- a/helm/strider/templates/health-config-map.yaml
+++ b/helm/strider/templates/health-config-map.yaml
@@ -1,0 +1,47 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "strider.fullname" . }}-heath-configmap
+  labels:
+    {{- include "strider.labels" . | nindent 4 }}
+data:
+  strider_health.sh: |-
+    #!/bin/bash
+    export status=$(timeout -s 3 $1 \
+    curl -s -o /dev/null -w "%{http_code}" -X 'POST' \
+      'http://localhost:{{ .Values.strider.container.port }}/query' \
+      -H 'accept: application/json' \
+      -H 'Content-Type: application/json' \
+      -d '{
+      "message": {
+        "query_graph": {
+          "nodes": {
+            "n0": {
+              "ids": [
+                "MONDO:0005148"
+              ],
+              "categories": [
+                "biolink:Disease"
+              ]
+            },
+            "n1": {
+              "categories": [
+                "biolink:PhenotypicFeature"
+              ]
+            }
+          },
+          "edges": {
+            "e01": {
+              "subject": "n0",
+              "object": "n1",
+              "predicates": [
+                "biolink:has_phenotype"
+              ]
+            }
+          }
+        }
+      }
+    }')
+    if [ "$status" != "200" ]; then
+      exit 1;
+    fi

--- a/helm/strider/templates/hpa.yaml
+++ b/helm/strider/templates/hpa.yaml
@@ -1,0 +1,28 @@
+{{- if .Values.strider.autoscaling.enabled }}
+apiVersion: autoscaling/v2beta1
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "strider.fullname" . }}-hpa
+  labels:
+    {{- include "strider.labels" . | nindent 4 }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "strider.fullname" . }}-web-server
+  minReplicas: {{ .Values.strider.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.strider.autoscaling.maxReplicas }}
+  metrics:
+    {{- if .Values.strider.autoscaling.targetCPU }}
+    - type: Resource
+      resource:
+        name: cpu
+        targetAverageUtilization: {{ .Values.strider.autoscaling.targetCPU }}
+    {{- end }}
+    {{- if .Values.strider.autoscaling.targetMemory }}
+    - type: Resource
+      resource:
+        name: memory
+        targetAverageUtilization: {{ .Values.strider.autoscaling.targetMemory }}
+    {{- end }}
+{{- end }}

--- a/helm/strider/templates/kp-registry-stateful-set.yaml
+++ b/helm/strider/templates/kp-registry-stateful-set.yaml
@@ -22,12 +22,20 @@ spec:
           image: "{{ .Values.kpRegistry.image.repository }}:{{ .Values.kpRegistry.image.tag }}"
           ports:
             - name: http
-              containerPort: 4983
+              containerPort: {{ .Values.kpRegistry.containerPort }}
               protocol: TCP
           volumeMounts:
             - mountPath: /home/murphy/data
               name: {{ include "strider.fullname" . }}-kp-registry-data-volume
               subPath: data
+          livenessProbe:
+            httpGet:
+              path: {{ .Values.probes.kpRegistry.path }}
+              port: http
+            failureThreshold: {{ .Values.probes.kpRegistry.failureThreshold }}
+            periodSeconds: {{ .Values.probes.kpRegistry.period }}
+            successThreshold: {{ .Values.probes.kpRegistry.successThreshold }}
+
   volumeClaimTemplates:
     - metadata:
         name: {{ include "strider.fullname" . }}-kp-registry-data-volume

--- a/helm/strider/templates/service.yaml
+++ b/helm/strider/templates/service.yaml
@@ -45,7 +45,7 @@ spec:
   type: {{ .Values.strider.service.type }}
   ports:
     - port: {{ .Values.strider.service.port }}
-      targetPort: 5781
+      targetPort: {{ .Values.strider.container.port }}
       protocol: TCP
       name: http
   selector:

--- a/helm/strider/templates/strider-deployment.yaml
+++ b/helm/strider/templates/strider-deployment.yaml
@@ -41,10 +41,33 @@ spec:
             - "--host"
             - "0.0.0.0"
             - "--port"
-            - "5781"
+            - "{{ .Values.strider.container.port }}"
             - "--root-path"
             - "/1.1"
+            - "--workers"
+            - "{{ .Values.strider.uvicornWorkerCount }}"
           ports:
             - name: http
-              containerPort: 5781
+              containerPort: {{ .Values.strider.container.port }}
               protocol: TCP
+          livenessProbe:
+            exec:
+              command:
+              - /strider_health.sh
+              - "{{ .Values.probes.strider.timeoutSeconds }}"
+            failureThreshold: {{ .Values.probes.strider.failureThreshold }}
+            periodSeconds: {{ .Values.probes.strider.period }}
+            successThreshold: {{ .Values.probes.strider.successThreshold }}
+            timeoutSeconds: {{ .Values.probes.strider.timeoutSeconds }}
+          {{ if .Values.strider.resources }}
+          resources: {{ toYaml .Values.strider.resources | nindent 12 }}
+          {{ end }}
+          volumeMounts:
+          - name: {{ include "strider.fullname" . }}-health-scripts
+            mountPath: /strider_health.sh
+            subPath: strider_health.sh
+      volumes:
+      - name: {{ include "strider.fullname" . }}-health-scripts
+        configMap:
+          name: {{ include "strider.fullname" . }}-heath-configmap
+          defaultMode: 0777

--- a/helm/strider/templates/update-kp-registry.yaml
+++ b/helm/strider/templates/update-kp-registry.yaml
@@ -1,0 +1,22 @@
+apiVersion: batch/v1beta1
+kind: CronJob
+metadata:
+  name: {{ include "strider.fullname" . }}-update-kp-registry
+spec:
+  schedule: "{{ .Values.kpRegistry.updateCronInterval }}"
+  successfulJobsHistoryLimit: 0
+  failedJobsHistoryLimit: 3
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          containers:
+          - name: job-container
+            image: busybox
+            imagePullPolicy: IfNotPresent
+            command:
+            - wget
+            - "http://{{ include "strider.fullname" . }}-kp-service:{{ .Values.kpRegistry.service.port }}/refresh"
+            - --post-data
+            - ""
+          restartPolicy: OnFailure

--- a/helm/strider/values.yaml
+++ b/helm/strider/values.yaml
@@ -14,6 +14,9 @@ kpRegistry:
   service:
     type: ClusterIP
     port: 80
+  containerPort: 4983
+  # every five minute
+  updateCronInterval: "*/1 * * * *"
 
 strider:
   replicaCount: 1
@@ -26,6 +29,40 @@ strider:
   service:
     type: ClusterIP
     port: 5781
+  container:
+    port: 5781
+  uvicornWorkerCount: 6
+
+  autoscaling:
+    enabled: true
+    minReplicas: 1
+    maxReplicas: 5
+    targetCPU: 40
+
+  resources:
+    requests:
+      memory: 2Gi
+      cpu: 500m
+    limits:
+      memory: 3.5Gi
+      cpu: 1000m
+
+
+
+# liveliness prob values
+probes:
+  strider:
+    failureThreshold: 5
+    successThreshold: 1
+    periodSeconds: 5
+    timeoutSeconds: 10
+
+  kpRegistry:
+    path: "/kps"
+    failureThreshold: 5
+    successThreshold: 1
+    periodSeconds: 5
+    timeoutSeconds: 3
 
 
 redis:


### PR DESCRIPTION
- Adds health Check for strider  , sending example query through post and checking for 200, default timeout for query is 10 seconds ( as resolved from `.Values.probes.strider.timeoutSeconds`) 
- Adds health check on kp registry for 200 on GET `/kps` endpoint 
- Adds auto pod scaler for strider based on memory usage. it is disabled by default. 
- Adds more workers to strider uvicorn server default worker numbers is 6
-  Adds cron job that runs every minute to update kp registry
