### PR TITLE
plater adds skip attributes

### DIFF
--- a/helm/plater/templates/configmap.yaml
+++ b/helm/plater/templates/configmap.yaml
@@ -45,3 +45,5 @@ data:
     {{ .Values.datasetDesc | toJson }}
   openapi-config.yaml: |-
 {{ tpl $open_api_config . | indent 4 }}
+  skip_attr.json: |
+    {{ .Values.skip_attributes | toJson }}

--- a/helm/plater/templates/plater-deployment.yaml
+++ b/helm/plater/templates/plater-deployment.yaml
@@ -74,6 +74,9 @@ spec:
             - mountPath: /home/plater/Plater/PLATER/openapi-config.yaml
               name: {{ include "plater.fullname" . }}-config-files
               subPath: openapi-config.yaml
+            - mountPath: /home/plater/Plater/skip_attr.json
+              name: {{ include "plater.fullname" . }}-config-files
+              subPath: skip_attr.json
       volumes:
         - name: {{ include "plater.fullname" . }}-config-files
           configMap:

--- a/helm/plater/values.yaml
+++ b/helm/plater/values.yaml
@@ -7,7 +7,7 @@ replicaCount: 1
 image:
   plater:
     repository: renciorg/plater-clustered
-    tag: "1.2.0-2"
+    tag: "1.2.0-3"
     imagePullPolicy: Always
   neo4j:
     repository: renciorg/neo4j-4.2-apoc-gds
@@ -110,6 +110,11 @@ app:
         # https://automat-dev.renci.org/<chart install name>
         url: ""
 dataUrl: ""
+
+skip_attributes:
+  - provided_by
+  - knowledge_source
+
 datasetDesc:
   version: ''
   description: ''


### PR DESCRIPTION
bumps image version to latest build
adds skip attributes config to chart,
 - provided_by : added on nodes by kgx
 - knowledge_source: added on edges by kgx
both of these attributes contain the file names where the entities were residing