### PR TITLE
Split loader as compendia and conflation jobs

### DIFF
--- a/helm/node-normalization-loader/templates/data-pvc.yaml
+++ b/helm/node-normalization-loader/templates/data-pvc.yaml
@@ -1,7 +1,18 @@
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
-  name: "{{ include "node-normalization-loader.fullname" . }}-data-pvc"
+  name: "{{ include "node-normalization-loader.fullname" . }}-conflation-pvc"
+spec:
+  accessModes:
+  - ReadWriteOnce
+  resources:
+    requests:
+      storage: {{ .Values.data.storageSize }}
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: "{{ include "node-normalization-loader.fullname" . }}-compendia-pvc"
 spec:
   accessModes:
   - ReadWriteOnce

--- a/helm/node-normalization-loader/templates/loader-config.yaml
+++ b/helm/node-normalization-loader/templates/loader-config.yaml
@@ -3,18 +3,50 @@ kind: ConfigMap
 metadata:
   name: "{{- include "node-normalization-loader.fullname" . }}-loader-config"
 data:
-  config.json: |-
+  config-compendia.json: |-
     {
     "compendium_directory": "/data/",
-    "data_files": "data.txt",
+    "conflation_directory": "/data/",
+    "data_files": ["data.txt"],
     "test_mode": 0,
-    "debug_messages": 1
+    "debug_messages": 1,
+    "conflations" : []
     }
-  run_loader.sh: |-
+  config-conflation.json: |-
+    {
+    "compendium_directory": "/data/",
+    "conflation_directory": "/data/",
+    "data_files": [],
+    "test_mode": 0,
+    "debug_messages": 1,
+    "conflations" : [{{ range $conflation := .Values.data.conflations.configs }}
+        {
+          "types" : {{ $conflation.types | toJson }},
+          "file": "{{ $conflation.file }}",
+          "redis_db": "{{ $conflation.redis_db }}"
+        } {{ end }}
+      ]
+    }
+  run_loader_conflation.sh: |-
     #!/bin/sh -x
     export DATA_DIR=/data
-    {{ $baseURL := .Values.data.sourceBaseUrl }}
-    export data_files="{{ range $file := .Values.data.files }}{{ printf "%s%s " $baseURL $file }}{{end}}"
+    {{ $baseURL := .Values.data.conflations.sourceBaseUrl }}
+    export data_files="{{ range $config := .Values.data.conflations.configs }}{{ printf "%s%s " $baseURL $config.file }}{{end}}"
+    export file_names="{{ range $config := .Values.data.conflations.configs }}{{ printf $config.file }}{{end}}"
+    for file in $data_files; do
+      echo DOWNLOADING $file
+      wget -nv -P $DATA_DIR $file
+    done
+    python load.py
+    for file in $file_names; do
+          rm $DATA_DIR/$file
+    done
+    echo "FINISHED"
+  run_loader_compendia.sh: |-
+    #!/bin/sh -x
+    export DATA_DIR=/data
+    {{ $baseURL := .Values.data.compendia.sourceBaseUrl }}
+    export data_files="{{ range $file := .Values.data.compendia.files }}{{ printf "%s%s " $baseURL $file }}{{end}}"
     for file in $data_files; do
       echo DOWNLOADING $file
       wget -nv -O $DATA_DIR/data.txt $file

--- a/helm/node-normalization-loader/templates/loader-job.yaml
+++ b/helm/node-normalization-loader/templates/loader-job.yaml
@@ -1,11 +1,11 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: "{{- include "node-normalization-loader.fullname" . }}-job"
+  name: "{{- include "node-normalization-loader.fullname" . }}-com-job"
 spec:
   template:
     metadata:
-      name: "{{- include "node-normalization-loader.fullname" . }}-job"
+      name: "{{- include "node-normalization-loader.fullname" . }}-com-job"
     spec:
       containers:
         - name: loader-container
@@ -16,7 +16,7 @@ spec:
           volumeMounts:
             - mountPath:  /home/murphy/run_loader.sh
               name: "loader-config"
-              subPath: "run_loader.sh"
+              subPath: "run_loader_compendia.sh"
             - mountPath: /data
               name: "data-dir"
             - mountPath: /home/murphy/redis_config.yaml
@@ -24,7 +24,7 @@ spec:
               subPath: "redis_config.yaml"
             - mountPath: /home/murphy/config.json
               name: "loader-config"
-              subPath: "config.json"
+              subPath: "config-compendia.json"
           resources:
             {{ .Values.resources | toYaml | nindent 12 }}
       restartPolicy: OnFailure
@@ -36,4 +36,43 @@ spec:
             defaultMode: 0777
         - name: data-dir
           persistentVolumeClaim:
-            claimName: "{{ include "node-normalization-loader.fullname" . }}-data-pvc"
+            claimName: "{{ include "node-normalization-loader.fullname" . }}-compendia-pvc"
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: "{{- include "node-normalization-loader.fullname" . }}-con-job"
+spec:
+  template:
+    metadata:
+      name: "{{- include "node-normalization-loader.fullname" . }}-con-job"
+    spec:
+      containers:
+        - name: loader-container
+          image: "{{ .Values.image.repository}}:{{ .Values.image.tag }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          command:
+            - /home/murphy/run_loader.sh
+          volumeMounts:
+            - mountPath:  /home/murphy/run_loader.sh
+              name: "loader-config"
+              subPath: "run_loader_conflation.sh"
+            - mountPath: /data
+              name: "data-dir"
+            - mountPath: /home/murphy/redis_config.yaml
+              name: "loader-config"
+              subPath: "redis_config.yaml"
+            - mountPath: /home/murphy/config.json
+              name: "loader-config"
+              subPath: "config-conflation.json"
+          resources:
+            {{ .Values.resources | toYaml | nindent 12 }}
+      restartPolicy: OnFailure
+      volumes:
+        - name: loader-config
+          configMap:
+            name: "{{ include "node-normalization-loader.fullname" . }}-loader-config"
+            defaultMode: 0777
+        - name: data-dir
+          persistentVolumeClaim:
+            claimName: "{{ include "node-normalization-loader.fullname" . }}-conflation-pvc"

--- a/helm/node-normalization-loader/values.yaml
+++ b/helm/node-normalization-loader/values.yaml
@@ -4,56 +4,101 @@
 
 image:
   repository: "renciorg/r3_nodenorm"
-  tag: "test-cluster-loader"
+  tag: "latest"
   pullPolicy: Always
 
 data:
   storageSize: 30G
-  sourceBaseUrl: "https://stars.renci.org/var/babel_outputs/biolink-2.1/"
-  files:
-    - AnatomicalEntity.txt
-    - BiologicalProcess.txt
-    - Cell.txt
-    - CellularComponent.txt
-    - ChemicalEntity.txt
-    - ChemicalMixture.txt
-    - ComplexMolecularMixture.txt
-    - Disease.txt
-    - GeneFamily.txt
-    - Gene.txt
-    - GrossAnatomicalStructure.txt
-    - MolecularActivity.txt
-    - MolecularMixture.txt
-    - OrganismTaxon.txt
-    - Pathway.txt
-    - PhenotypicFeature.txt
-    - Polypeptide.txt
-    - Protein.txtaa
-    - Protein.txtab
-    - Protein.txtac
-    - Protein.txtad
-    - Protein.txtae
-    - SmallMolecule.txtaa
-    - SmallMolecule.txtab
+  compendia:
+    sourceBaseUrl: "https://stars.renci.org/var/babel_outputs/biolink-2.1-conflated-v1.0/compendia/"
+    files:
+      - AnatomicalEntity.txt
+      - BiologicalProcess.txt
+      - Cell.txt
+      - CellularComponent.txt
+      - ChemicalEntity.txt
+      - ChemicalMixture.txt
+      - ComplexMolecularMixture.txt
+      - Disease.txt
+      - GeneFamily.txt
+      - Gene.txt
+      - GrossAnatomicalStructure.txt
+      - MolecularActivity.txt
+      - MolecularMixture.txt
+      - OrganismTaxon.txt
+      - Pathway.txt
+      - PhenotypicFeature.txt
+      - Polypeptide.txt
+      - Protein.txtaa
+      - Protein.txtab
+      - Protein.txtac
+      - Protein.txtad
+      - Protein.txtae
+      - Protein.txtaf
+      - Protein.txtag
+      - Protein.txtah
+      - Protein.txtai
+      - Protein.txtaj
+      - SmallMolecule.txtaa
+      - SmallMolecule.txtab
+      - SmallMolecule.txtac
+      - SmallMolecule.txtad
+      - SmallMolecule.txtae
+      - SmallMolecule.txtaf
+      - SmallMolecule.txtag
+      - SmallMolecule.txtah
+      - SmallMolecule.txtai
+      - SmallMolecule.txtaj
+  conflations:
+    sourceBaseUrl: https://stars.renci.org/var/babel_outputs/biolink-2.1-conflated-v1.0/conflation/
+    configs:
+      - file: "GeneProtein.txt"
+        types:
+          - biolink:Gene
+          - biolink:Protein
+        redis_db: "gene_protein_db"
 
 
 redis_backend_config:
-  "eq_id_to_id_db" :
-    "is_cluster": true
+  "eq_id_to_id_db":
+    "ssl_enabled": false
+    "is_cluster": false
+    "db": 0
     "hosts":
-      - "host_name": "redis-cluster-redis-id-id-shard-headless"
+      # list of cluster member ips and ports
+      - "host_name": "host"
         "port": "6379"
     "password": "password"
-  "id_to_data_db":
-    "is_cluster": true
+  "id_to_eqids_db":
+    "ssl_enabled": false
+    "is_cluster": false
+    "db": 0
     "hosts":
-      - "host_name": "redis-cluster-redis-id-data-shard-headless"
+      - "host_name": "host"
+        "port": "6379"
+    "password": "password"
+  "id_to_type_db":
+    "ssl_enabled": false
+    "is_cluster": false
+    "db": 0
+    "hosts":
+      - "host_name": "host"
         "port": "6379"
     "password": "password"
   "curie_to_bl_type_db":
-    "is_cluster": true
+    "ssl_enabled": false
+    "is_cluster": false
+    "db": 0
     "hosts":
-      - "host_name": "redis-cluster-redis-curie-type-master"
+      - "host_name": "host"
+        "port": "6379"
+    "password": "password"
+  "gene_protein_db":
+    "ssl_enabled": false
+    "is_cluster": false
+    "db": 0
+    "hosts":
+      - "host_name": "host"
         "port": "6379"
     "password": "password"
 

--- a/helm/redis-r3-external/Chart.yaml
+++ b/helm/redis-r3-external/Chart.yaml
@@ -32,7 +32,15 @@ dependencies:
   - name: redis
     version: "12.7.4"
     repository: "https://charts.bitnami.com/bitnami"
-    alias: id-node
+    alias: id-eq-id
+  - name: redis
+    version: "12.7.4"
+    repository: "https://charts.bitnami.com/bitnami"
+    alias: id-categories
+  - name: redis
+    version: "12.7.4"
+    repository: "https://charts.bitnami.com/bitnami"
+    alias:  conflation-db
   - name: redis
     version: "12.7.4"
     repository: "https://charts.bitnami.com/bitnami"

--- a/helm/redis-r3-external/values.yaml
+++ b/helm/redis-r3-external/values.yaml
@@ -5,7 +5,7 @@ id-id:
   master:
     resources:
       requests:
-        memory: #120Gi
+        memory: #
     readinessProbe:
       enabled: false
     livenessProbe:
@@ -13,8 +13,21 @@ id-id:
   cluster:
     slaveCount: 0
 
+id-categories:
+  auth:
+    enabled: true
+  master:
+    readinessProbe:
+      enabled: false
+    livenessProbe:
+      enabled: false
+    resources:
+      requests:
+        memory: #
+  cluster:
+    slaveCount: 0
 
-id-node:
+id-eq-id:
   auth:
     enabled: true
   master:
@@ -38,6 +51,20 @@ semantic-count:
       enabled: false
     resources:
       requests:
-        memory: #2Gi
+        memory: #
+  cluster:
+    slaveCount: 0
+
+conflation-db:
+  auth:
+    enabled: true
+  master:
+    readinessProbe:
+      enabled: false
+    livenessProbe:
+      enabled: false
+    resources:
+      requests:
+        memory: #
   cluster:
     slaveCount: 0


### PR DESCRIPTION
when loading using  a single job conflation is done for every compendia. This PR will split them into two jobs. The conflation job just loads the conflation files, likewise compendia job loads each compendia file.

- also update redis external chart , includes 2 mode dbs that had not been pushed to the repo 