### PR TITLE
Plater strider updates

### DIFF
--- a/helm/plater/templates/neo4j-deployment.yaml
+++ b/helm/plater/templates/neo4j-deployment.yaml
@@ -94,6 +94,14 @@ spec:
           livenessProbe:
 {{ toYaml .Values.neo4j.livenessProbe | indent 12 }}
       restartPolicy: Always
+    {{ with .Values.neo4j.affinity }}
+      affinity:
+        {{ toYaml . | nindent 8 }}
+    {{ end }}
+    {{ with .Values.neo4j.tolerations }}
+      tolerations:
+      {{ toYaml . | nindent 8 }}
+    {{ end }}
       volumes:
         - name: {{ include "plater.fullname" . }}-scripts
           configMap:

--- a/helm/plater/values.yaml
+++ b/helm/plater/values.yaml
@@ -55,6 +55,8 @@ neo4j:
         - bash
         - -c
         - IFS="/" read -a auth <<< $NEO4J_AUTH ; cypher-shell -u ${auth[0]} -p ${auth[1]} "match (c) return c limit 1"
+  tolerations:
+  affinity:
 
 service:
   type: ClusterIP

--- a/helm/strider/templates/strider-deployment.yaml
+++ b/helm/strider/templates/strider-deployment.yaml
@@ -52,6 +52,7 @@ spec:
             - name: http
               containerPort: {{ .Values.strider.container.port }}
               protocol: TCP
+          {{ if .Values.probes.strider.enabled }}
           livenessProbe:
             exec:
               command:
@@ -61,6 +62,7 @@ spec:
             periodSeconds: {{ .Values.probes.strider.period }}
             successThreshold: {{ .Values.probes.strider.successThreshold }}
             timeoutSeconds: {{ .Values.probes.strider.timeoutSeconds }}
+          {{ end }}
           {{ if .Values.strider.resources }}
           resources: {{ toYaml .Values.strider.resources | nindent 12 }}
           {{ end }}

--- a/helm/strider/values.yaml
+++ b/helm/strider/values.yaml
@@ -51,16 +51,17 @@ strider:
 # liveliness prob values
 probes:
   strider:
+    enabled: false
     failureThreshold: 5
     successThreshold: 1
-    periodSeconds: 5
+    periodSeconds: 120
     timeoutSeconds: 10
 
   kpRegistry:
     path: "/kps"
     failureThreshold: 5
     successThreshold: 1
-    periodSeconds: 5
+    periodSeconds: 120
     timeoutSeconds: 3
 
 


### PR DESCRIPTION
- Adds node affinity and tolerations to enable selection of specific nodes to run neo4j on for plater. 
- Strider liveliness probe enable disable flag, and default period to 120s 