### PR TITLE
DRAFT: change target for cronjob

### DIFF
--- a/helm/api-watchdog/templates/cronjob.yaml
+++ b/helm/api-watchdog/templates/cronjob.yaml
@@ -16,5 +16,5 @@ spec:
             imagePullPolicy: {{ .Values.image.pullPolicy }}
             command:
             - bash
-            - startup.sh
+            - fetch-and-exec.sh
           restartPolicy: OnFailure


### PR DESCRIPTION
draft pr for api-watchdog cronjob

I think I need to add 
- the name of the command `bash fetch-and-exec.sh`
- image (not uploaded yet) 