### PR TITLE
adding security context to avoid the use of root in the pod

### DIFF
--- a/helm/aragorn/templates/deployment.yaml
+++ b/helm/aragorn/templates/deployment.yaml
@@ -17,6 +17,11 @@ spec:
         app: {{ include "aragorn.name" . }}
         trapi: "1.2"
     spec:
+      securityContext:
+        runAsUser: 1001
+        fsGroup: 2000
+        runAsGroup: 3000
+
       containers:
         - name: {{ .Chart.Name }}-web-container
           image: {{ .Values.image.repository }}:{{ .Values.image.tag }}


### PR DESCRIPTION
a securityConext has been added. this has to me mated with a container that specifies  the non-root user.