### PR TITLE
Disables AOF and add .enabled for redis chart

### DIFF
--- a/helm/redis-r3-external/Chart.yaml
+++ b/helm/redis-r3-external/Chart.yaml
@@ -49,3 +49,4 @@ dependencies:
     version: "12.7.4"
     repository: "https://charts.bitnami.com/bitnami"
     alias: info-content
+    condition: info-content.enabled

--- a/helm/redis-r3-external/values.yaml
+++ b/helm/redis-r3-external/values.yaml
@@ -10,6 +10,11 @@ id-id:
       enabled: false
     livenessProbe:
       enabled: false
+    extraFlags:
+    - "--save"
+    - '"60 10000"'
+    - "--appendonly no"
+
   cluster:
     slaveCount: 0
 
@@ -24,6 +29,11 @@ id-categories:
     resources:
       requests:
         memory: #
+    extraFlags:
+    - "--save"
+    - '"60 10000"'
+    - "--appendonly no"
+
   cluster:
     slaveCount: 0
 
@@ -38,6 +48,10 @@ id-eq-id:
     resources:
       requests:
         memory: #200Gi
+    extraFlags:
+    - "--save"
+    - '"60 10000"'
+    - "--appendonly no"
   cluster:
     slaveCount: 0
 
@@ -52,6 +66,10 @@ semantic-count:
     resources:
       requests:
         memory: #
+    extraFlags:
+    - "--save"
+    - '"60 10000"'
+    - "--appendonly no"
   cluster:
     slaveCount: 0
 
@@ -66,6 +84,10 @@ conflation-db:
     resources:
       requests:
         memory: #
+    extraFlags:
+    - "--save"
+    - '"60 10000"'
+    - "--appendonly no"
   cluster:
     slaveCount: 0
 
@@ -80,5 +102,9 @@ info-content:
     resources:
       requests:
         memory: #
+    extraFlags:
+    - "--save"
+    - '"60 10000"'
+    - "--appendonly no"
   cluster:
     slaveCount: 0


### PR DESCRIPTION
- this is some commits that i had previously missed to push
- it disables AOF, since AOF dumps are unnecessarily large for our use case it causes larger volume usage
- it adds enabled flag for Info-content redis deployment 