### PR TITLE
ingress class as attribute if version above 1.18

### DIFF
--- a/helm/node-normalization-web-server/templates/ingress.yaml
+++ b/helm/node-normalization-web-server/templates/ingress.yaml
@@ -25,6 +25,9 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
+  {{- if and .Values.ingress.class (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion) }}
+  ingressClassName: {{ .Values.ingress.class }}
+  {{- end }}
   {{- if .Values.ingress.tls }}
   tls:
     {{- range .Values.ingress.tls }}
@@ -71,6 +74,9 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
+  {{- if and .Values.ingress.class (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion) }}
+  ingressClassName: {{ .Values.ingress.class }}
+  {{- end }}
   {{- if .Values.ingress.tls }}
   tls:
     {{- range .Values.ingress.tls }}


### PR DESCRIPTION
Adds ingress class attibuite for NN webserver. 
ITRB uses "nginx" ingress class, but it wasn't being reflected due to this missing lines.