### PR TITLE
Remove reliance on docker socket for monitoring tests

### DIFF
--- a/monitoring/Jenkinsfile
+++ b/monitoring/Jenkinsfile
@@ -3,22 +3,11 @@ pipeline {
         kubernetes {
             cloud 'kubernetes'
             yaml '''
-              apiVersion: v1
-              kind: Pod
               spec:
                 containers:
-                - name: agent-docker
-                  image: helxplatform/agent-docker:latest
-                  command:
-                  - cat
-                  tty: true
-                  volumeMounts:
-                    - name: dockersock
-                      mountPath: "/var/run/docker.sock"
-                volumes:
-                - name: dockersock
-                  hostPath:
-                    path: /var/run/docker.sock
+                - name: artillery
+                  image: renciorg/artillery:2.0.0-5-expect-plugin
+                  command: ["sleep", "1200"]
             '''
         }
     }
@@ -30,14 +19,14 @@ pipeline {
                     env.ARTILLERY_CONF = params.test_spec
                     env.EMAIL_RECIPIENTS = params.email_recipients
                 }
-                container('agent-docker') {
-                    sh '''
-                    cd monitoring
-                    echo server : $SERVER_URL
-                    echo test_spec: $ARTILLERY_CONF
-                    chmod +x -R ./run_test.sh
-                    ./run_test.sh -t $ARTILLERY_CONF -s $SERVER_URL
-                    '''
+                container('artillery') {
+                    dir('monitoring') {
+                        sh '''
+                        echo server : $SERVER_URL
+                        echo test_spec: $ARTILLERY_CONF
+                        ./run_test.sh -t $ARTILLERY_CONF -s $SERVER_URL
+                        '''
+                    }
                 }
             }
         }

--- a/monitoring/run_test.sh
+++ b/monitoring/run_test.sh
@@ -1,4 +1,5 @@
-#!/bin/bash
+#!/bin/ash
+# This runs inside renciorg/artillery which is alpine-based (ash)
 
 # stop test if any of the steps fail -x
 set -ax
@@ -24,50 +25,35 @@ function validate() {
 function run_artillery() {
   test_file=$1
   server_url=$2
-  container_id=$( \
-      docker run \
-         -d -it \
-         --env SERVER_URL=$server_url \
-         --env DEBUG=http*,plugin:expect \
-         --env ARTILLERY_PLUGIN_PATH="/plugins" \
-         --entrypoint "/bin/sh" \
-         renciorg/artillery:2.0.0-5-expect-plugin
-      )
 
-  # Copy files
-  docker cp "${PWD}/test-specs/${test_file}" $container_id:/test.yaml
-  docker cp "${PWD}/test-specs/data/" $container_id:/data/
-#  docker cp "${PWD}/test-specs/plugins" $container_id:/plugins/
+  export SERVER_URL=$server_url
+  export DEBUG='http*,plugin:expect'
+  export ARTILLERY_PLUGIN_PATH=${PWD}/test-specs/plugins
+  # https://wiki.renci.org/index.php/Kubernetes_Cloud/Sterling#Pods_can't_access_Ingress_hostnames
+  export HTTPS_PROXY=http://proxy.renci.org:8080
+  export HTTP_PROXY=http://proxy.renci.org:8080
 
-  docker exec $container_id  artillery run --output /report.json /test.yaml > test_output.yaml
+  artillery run --output report.json "${PWD}/test-specs/${test_file}" > test_output.yaml
   has_error=$?
-  docker exec $container_id  artillery report --output /report.html /report.json
-  docker cp $container_id:/report.html "report.html"
-  docker cp $container_id:/report.json "report.json"
+  artillery report --output report.html report.json
 
   if grep -i "errors.enotfound" test_output.yaml; then
     echo "server address ${server_url} not found"
-    docker rm -f $container_id
     exit 1
   fi
   if grep -i "errors.etimedout" test_output.yaml; then
     echo "server address ${server_url} timed out in a test"
-    docker rm -f $container_id
     exit 1
   fi
 
 
   if [ $has_error -eq 1 ]; then
     echo "error found check reports"
-    docker rm -f $container_id
     exit 1
   else
     echo "SUCCESS"
-    docker rm -f $container_id
     exit 0
   fi
-
-  docker rm -f $container_id
 
   exit 0
 }


### PR DESCRIPTION
Since jenkins2.renci.org (blackbalsam) is moving to jenkins.apps.renci.org (Sterling), jobs can no longer rely on the docker socket if they want to run in Kubernets pods (preferred). Since these jobs don't rely on multiple containers, they didn't need the docker socket; the artillery container can be run directly by Jenkins via the k8s API.

Here's a successful build of this change: https://jenkins.apps.renci.org/job/Translator/job/Service%20health%20monitoring/job/Node%20normalization/job/node%20normalization%20(renci)%20DEV/4164/