### PR TITLE
Run artillery pod as a non-root user

### DIFF
--- a/monitoring/Jenkinsfile
+++ b/monitoring/Jenkinsfile
@@ -8,6 +8,8 @@ pipeline {
                 - name: artillery
                   image: renciorg/artillery:2.0.0-5-expect-plugin
                   command: ["sleep", "1200"]
+                  securityContext:
+                    runAsUser: 1000
             '''
         }
     }


### PR DESCRIPTION
I'm getting frequent [Falco](https://falco.org/) alerts from these jobs about writing files below "/" or "/root". But strangely, I don't think the script actually does that. I suspect Falco is just getting confused somewhere.

Regardless, running as non-root is always a good idea :)

Tested here: https://jenkins.apps.renci.org/job/Translator/job/Service%20health%20monitoring/job/Name%20Resolution/job/Name%20resolution%20(renci)%20DEV/4189/console