### PR TITLE
Fix bug in RENCI deployment in CAM-KP-API

### DIFF
--- a/helm/cam-kp-api/values.yaml
+++ b/helm/cam-kp-api/values.yaml
@@ -15,7 +15,7 @@ ingress:
   pathType: ImplementationSpecific
   timeout: 7200 # 1hr
   tls:
-    enabled: false # We need a default to deploy this to RENCI
+    enabled: true # We need a default to deploy this to RENCI
   annotations:
     nginx.ingress.kubernetes.io/enable-cors: "true"
     nginx.ingress.kubernetes.io/rewrite-target: /$2


### PR DESCRIPTION
Turns out RENCI needs ingress.tls.enabled to be 'true', not 'false'. My bad!