### PR TITLE
We're changing the Helm name of NodeNorm from `nn-web-server` to `nn-web`

### DIFF
--- a/helm/node-normalization-web-server/templates/NOTES.txt
+++ b/helm/node-normalization-web-server/templates/NOTES.txt
@@ -1,4 +1,4 @@
 1. Several RENCI services depend on NodeNorm running with a particular service
-   name, so please don't change either the release name (`nn-web-server`) or
+   name, so please don't change either the release name (`nn-web`) or
    the namespace without checking with Yaphet or whoever is running Aragorn and
    other RENCI Translator services.


### PR DESCRIPTION
The Helm name is important because Aragorn accesses NodeNorm RENCI via its cluster name, so it's important that this remain unchanged. AFAIK there's no way of changing this from within the Helm chart (please correct me if I'm wrong!), so I've added it to the NOTES.txt file so it's displayed after deployments. A more long-term solution would be to have a NodeNorm user on Sterling (maybe Aragorn?) periodically check whether NodeNorm is up under a particular name, and to ping me or someone if that's not the case.

(Checking this from outside the cluster is covered by https://github.com/TranslatorSRI/NodeNormalization/issues/161, but we also need some way of checking this from inside the cluster.)