### PR TITLE
Modified redis-r3-external to save to disk less often

### DIFF
--- a/helm/redis-r3-external/values.yaml
+++ b/helm/redis-r3-external/values.yaml
@@ -140,7 +140,7 @@ info-content:
       requests:
         memory: #
     extraFlags:
-    - "--save 300 100000"
+    - "--save 300 1000000"
     - "--appendonly no"
   cluster:
     slaveCount: 0

--- a/helm/redis-r3-external/values.yaml
+++ b/helm/redis-r3-external/values.yaml
@@ -17,7 +17,7 @@ id-id:
     livenessProbe:
       enabled: false
     extraFlags:
-    - "--save 60 10000"
+    - "--save 300 1000000"
     - "--appendonly no"
 
   cluster:
@@ -41,7 +41,7 @@ id-categories:
     livenessProbe:
       enabled: false
     extraFlags:
-    - "--save 60 10000"
+    - "--save 300 1000000"
     - "--appendonly no"
 
   cluster:
@@ -65,7 +65,7 @@ id-eq-id:
     livenessProbe:
       enabled: false
     extraFlags:
-    - "--save 60 10000"
+    - "--save 300 1000000"
     - "--appendonly no"
   cluster:
     slaveCount: 0
@@ -91,7 +91,7 @@ semantic-count:
       requests:
         memory: #
     extraFlags:
-    - "--save 60 10000"
+    - "--save 300 1000000"
     - "--appendonly no"
   cluster:
     slaveCount: 0
@@ -114,7 +114,7 @@ conflation-db:
     livenessProbe:
       enabled: false
     extraFlags:
-    - "--save 60 10000"
+    - "--save 300 1000000"
     - "--appendonly no"
   cluster:
     slaveCount: 0

--- a/helm/redis-r3-external/values.yaml
+++ b/helm/redis-r3-external/values.yaml
@@ -140,7 +140,7 @@ info-content:
       requests:
         memory: #
     extraFlags:
-    - "--save 60 10000"
+    - "--save 300 100000"
     - "--appendonly no"
   cluster:
     slaveCount: 0


### PR DESCRIPTION
The previous setting was `--save 60 10000`. I've increased that to `--save 300 1000000`, i.e. save every 5 minutes if there has been at least 1_000_000 changes since the last change. This should force the Redis server to perform fewer saves when loading new data. See https://redis.io/docs/management/persistence/#snapshotting for details on this command and how Redis does snapshotting.

WIP Need to test this out.