### PR TITLE
Turned on slower saves and append for Redis instances

### DIFF
--- a/helm/redis-r3-external/.helmignore
+++ b/helm/redis-r3-external/.helmignore
@@ -1,3 +1,7 @@
+# We use scripts/ to hold some scripts that are only needed for testing;
+# this should not be included in the Helm.
+/scripts/
+
 # Patterns to ignore when building packages.
 # This supports shell glob matching, relative path matching, and
 # negation (prefixed with !). Only one pattern per line.

--- a/helm/redis-r3-external/values.yaml
+++ b/helm/redis-r3-external/values.yaml
@@ -17,8 +17,8 @@ id-id:
     livenessProbe:
       enabled: false
     extraFlags:
-    - "--save 60 10000"
-    - "--appendonly no"
+    - "--save 300 100000"
+    - "--appendonly yes"
 
   cluster:
     slaveCount: 0
@@ -41,8 +41,8 @@ id-categories:
     livenessProbe:
       enabled: false
     extraFlags:
-    - "--save 60 10000"
-    - "--appendonly no"
+    - "--save 300 100000"
+    - "--appendonly yes"
 
   cluster:
     slaveCount: 0
@@ -65,8 +65,8 @@ id-eq-id:
     livenessProbe:
       enabled: false
     extraFlags:
-    - "--save 60 10000"
-    - "--appendonly no"
+    - "--save 300 100000"
+    - "--appendonly yes"
   cluster:
     slaveCount: 0
 
@@ -91,8 +91,8 @@ semantic-count:
       requests:
         memory: #
     extraFlags:
-    - "--save 60 10000"
-    - "--appendonly no"
+    - "--save 300 100000"
+    - "--appendonly yes"
   cluster:
     slaveCount: 0
 
@@ -114,8 +114,8 @@ conflation-db:
     livenessProbe:
       enabled: false
     extraFlags:
-    - "--save 60 10000"
-    - "--appendonly no"
+    - "--save 300 100000"
+    - "--appendonly yes"
   cluster:
     slaveCount: 0
 
@@ -140,7 +140,7 @@ info-content:
       requests:
         memory: #
     extraFlags:
-    - "--save 60 10000"
-    - "--appendonly no"
+    - "--save 300 100000"
+    - "--appendonly yes"
   cluster:
     slaveCount: 0

--- a/helm/redis-r3-external/values.yaml
+++ b/helm/redis-r3-external/values.yaml
@@ -8,10 +8,10 @@ id-id:
     resources:
       limits:
         cpu: 1500m
-        memory: 80Gi
+        memory: 150Gi
       requests:
         cpu: 200m
-        memory: 50Gi
+        memory: 100Gi
     readinessProbe:
       enabled: false
     livenessProbe:


### PR DESCRIPTION
The previous save setting was `--save 60 10000`. I've increased that to `--save 300 1000000`, i.e. save every 5 minutes if there has been at least 1_000_000 changes since the last change. This should force the Redis server to perform fewer saves when loading new data. See https://redis.io/docs/management/persistence/#snapshotting for details on this command and how Redis does snapshotting. Might help with #616.

This PR also increases the id-id memory to a limit of 150Gi and a request of 100Gi.