### PR TITLE
bump aragorn memory

### DIFF
--- a/helm/aragorn/values.yaml
+++ b/helm/aragorn/values.yaml
@@ -56,7 +56,7 @@ app:
       memory: 2Gi
       cpu: 1000m
     limits:
-      memory: 5Gi
+      memory: 20Gi
       cpu: 1000m
   logLevel: "trace"
   queueStorageSize: 10Gi


### PR DESCRIPTION
bumps aragorn memory to 20Gi
- temporary fix till we get discussed changes