### PR TITLE
Decrease Name-Res storage to 300Gi by deleting the downloaded Solr backup

### DIFF
--- a/helm/name-lookup/templates/scripts-config-map.yaml
+++ b/helm/name-lookup/templates/scripts-config-map.yaml
@@ -16,7 +16,7 @@ data:
     wget -nv -O $DATA_DIR/$BACKUP_ZIP $BACKUP_URL
     cd $DATA_DIR
     tar -xf $DATA_DIR/$BACKUP_ZIP -C $DATA_DIR
-  #    rm $BACKUP_ZIP
+    rm $DATA_DIR/$BACKUP_ZIP
   restore.sh: |-
     #!/bin/sh
     set -xa

--- a/helm/name-lookup/values.yaml
+++ b/helm/name-lookup/values.yaml
@@ -43,10 +43,10 @@ solr:
       memory: "64Gi"
     limits:
       memory: "64Gi"
-  # As of Babel 2023may18, we need 128G to store the
-  # backup + uncompressed backup + Solr database
-  # So 500Gi should be enough for the time being.
-  storage: 500Gi
+  # As of Babel 2023jul13, we need 130G to store the
+  # uncompressed backup + 131G Solr database
+  # So 300Gi should be enough for the time being.
+  storage: 300Gi
 
   initresources:
     requests:


### PR DESCRIPTION
We don't need to keep the downloaded Solr backup around. This PR modifies the download script to delete that file once it has been uncompressed.

In the future, it would be great if we could delete the uncompressed backup as well (/var/solr/data/var/solr/data/...), but this would need to happen after the restore.