### PR TITLE
Add LOAD_DATA parameter for name-lookup

### DIFF
--- a/jenkins/name-lookup/Jenkinsfile
+++ b/jenkins/name-lookup/Jenkinsfile
@@ -11,6 +11,7 @@ pipeline {
         string(name: 'BUILD_VERSION', defaultValue: '', description: 'The build version to deploy (optional)')
         string(name: 'AWS_REGION', defaultValue: 'us-east-1', description: 'AWS Region to deploy')
         string(name: 'KUBERNETES_CLUSTER_NAME', defaultValue: 'translator-eks-ci-blue-cluster', description: 'AWS EKS that will host this application')
+        choice(name: 'LOAD_DATA', choices: 'no\nyes', description: 'Load data or not, default no')
     }
     triggers {
         pollSCM('H/2 * * * *')


### PR DESCRIPTION
This PR adds a LOAD_DATA parameter to name-lookup (or rather, copies the parameter already present in plater). If LOAD_DATA turns on or off the `--set dataUrl=''` parameter in `prepare.sh`, then this will work perfectly as-is. If it uses a different variable, we should rename that variable in the name-lookup Helm chart so that we don't need to customize `prepare.sh` for name-lookup. It looks like it uses `--set dataUrl=''` (as per [this line](https://github.com/helxplatform/translator-devops/blob/adc96a99c078b7e609d1bf4794732c6573d84997/helm/plater/values.yaml#L152)), but without looking at `prepare.sh` I can't be sure.

@YaphetKG Do you have any insights into the variable used by plater, and if this PR is likely to work?