### PR TITLE
NodeNorm loader fixes

### DIFF
--- a/helm/node-normalization-loader/ncats-images-meta.yaml
+++ b/helm/node-normalization-loader/ncats-images-meta.yaml
@@ -1,3 +1,3 @@
 nodeNormalizationLoader:
-  image: "containers.renci.org/translator/r3_nodenorm"
-  version: "2.0.9"
+  image: "ghcr.io/translatorsri/nodenormalization-data-loading"
+  tag: "v2.3.4"

--- a/helm/node-normalization-loader/templates/loader-pipe-job.yaml
+++ b/helm/node-normalization-loader/templates/loader-pipe-job.yaml
@@ -90,9 +90,7 @@ metadata:
 data:
   run_pipe.sh: |-
     #!/bin/bash
-    # TODO: turn `-e` back on: to preserve logs with error messages, we want to permasleep once
-    # the job is done, but with `-e` we exit out instead.
-    set -v -x
+    set -v -x -e
 
     # Delete everything in the dataDir.
     rm -f "{{ $dataDir }}/{{ $dbName }}.rdb.gz"
@@ -105,7 +103,7 @@ data:
     gunzip "{{ $dataDir }}/{{ $dbName }}.rdb.gz"
 
     # Restore the file into the specified database.
-    # But surpress MOVED messages
+    # But suppress MOVED messages, which -- with the `-c` option -- should be redundant.
     rdb -c protocol "{{ $dataDir }}/{{ $dbName }}.rdb" | redis-cli {{ if $isCluster }}-c{{end}} -h {{ $hostName }} -p {{ $port }} --pipe {{ if $sslEnabled -}}--tls{{ end }} 2>&1 | grep -v MOVED
 
     {{ if not $isCluster }}
@@ -113,11 +111,8 @@ data:
     redis-cli -h {{ $hostName }} -p {{ $port }} {{ if $sslEnabled -}}--tls{{ end }} {{ if $isCluster }}-c{{end}} BGSAVE
     {{- end }}
 
-    # Don't exit until we've had a chance to look at the logs
-    sleep 86400
-
     # Report success.
-    # echo "Completed restoring {{ $dbConf.restoreURL }} into {{ $dbName }} at {{ $hostName }}:{{ $port }}."
+    echo "Finished trying to restore {{ $dbConf.restoreURL }} into {{ $dbName }} at {{ $hostName }}:{{ $port }}."
 ---
 apiVersion: v1
 kind: Secret

--- a/helm/node-normalization-loader/templates/loader-pipe-job.yaml
+++ b/helm/node-normalization-loader/templates/loader-pipe-job.yaml
@@ -112,7 +112,7 @@ data:
     {{- end }}
 
     # Report success.
-    echo "Finished trying to restore {{ $dbConf.restoreURL }} into {{ $dbName }} at {{ $hostName }}:{{ $port }}."
+    echo "Completed restoring {{ $dbConf.restoreURL }} into {{ $dbName }} at {{ $hostName }}:{{ $port }}."
 ---
 apiVersion: v1
 kind: Secret

--- a/helm/node-normalization-loader/templates/loader-pipe-job.yaml
+++ b/helm/node-normalization-loader/templates/loader-pipe-job.yaml
@@ -16,6 +16,7 @@
 {{- $hostName := $host.host_name }}
 {{- $port := $host.port }}
 {{- $sslEnabled := $connectionDetails.ssl_enabled }}
+{{- $isCluster := $connectionDetails.is_cluster }}
 {{- $redisPassword := $connectionDetails.password }}
 apiVersion: batch/v1
 kind: Job
@@ -102,10 +103,12 @@ data:
     gunzip "{{ $dataDir }}/{{ $dbName }}.rdb.gz"
 
     # Restore the file into the specified database.
-    rdb -c protocol "{{ $dataDir }}/{{ $dbName }}.rdb" | redis-cli -h {{ $hostName }} -p {{ $port }} --pipe {{ if $sslEnabled -}}--tls{{ end }}
+    rdb -c protocol "{{ $dataDir }}/{{ $dbName }}.rdb" | redis-cli -h {{ $hostName }} -p {{ $port }} --pipe {{ if $sslEnabled -}}--tls{{ end }} {{ if $isCluster }}-c{{end}}
 
+    {{ if not $isCluster }}
     # Start a BGSAVE so the database is backed up to disk and ready to be loaded from if necessary.
-    redis-cli -h {{ $hostName }} -p {{ $port }} {{ if $sslEnabled -}}--tls{{ end }} BGSAVE
+    redis-cli -h {{ $hostName }} -p {{ $port }} {{ if $sslEnabled -}}--tls{{ end }} {{ if $isCluster }}-c{{end}} BGSAVE
+    {{- end }}
 
     # Report success.
     echo "Completed restoring {{ $dbConf.restoreURL }} into {{ $dbName }} at {{ $hostName }}:{{ $port }}."

--- a/helm/node-normalization-loader/templates/loader-pipe-job.yaml
+++ b/helm/node-normalization-loader/templates/loader-pipe-job.yaml
@@ -102,10 +102,10 @@ data:
     gunzip "{{ $dataDir }}/{{ $dbName }}.rdb.gz"
 
     # Restore the file into the specified database.
-    rdb -c protocol "{{ $dataDir }}/{{ $dbName }}.rdb" | redis-cli -h {{ $hostName }} -p {{ $port }} --pipe {{- if $sslEnabled -}}--tls{{- end }}
+    rdb -c protocol "{{ $dataDir }}/{{ $dbName }}.rdb" | redis-cli -h {{ $hostName }} -p {{ $port }} --pipe {{ if $sslEnabled -}}--tls{{ end }}
 
     # Start a BGSAVE so the database is backed up to disk and ready to be loaded from if necessary.
-    redis-cli -h {{ $hostName }} -p {{ $port }} {{- if $sslEnabled -}}--tls{{- end }} BGSAVE
+    redis-cli -h {{ $hostName }} -p {{ $port }} {{ if $sslEnabled -}}--tls{{ end }} BGSAVE
 
     # Report success.
     echo "Completed restoring {{ $dbConf.restoreURL }} into {{ $dbName }} at {{ $hostName }}:{{ $port }}."

--- a/helm/node-normalization-loader/templates/loader-pipe-job.yaml
+++ b/helm/node-normalization-loader/templates/loader-pipe-job.yaml
@@ -90,7 +90,9 @@ metadata:
 data:
   run_pipe.sh: |-
     #!/bin/bash
-    set -v -x -e
+    # TODO: turn `-e` back on: to preserve logs with error messages, we want to permasleep once
+    # the job is done, but with `-e` we exit out instead.
+    set -v -x
 
     # Delete everything in the dataDir.
     rm -f "{{ $dataDir }}/{{ $dbName }}.rdb.gz"
@@ -103,15 +105,19 @@ data:
     gunzip "{{ $dataDir }}/{{ $dbName }}.rdb.gz"
 
     # Restore the file into the specified database.
-    rdb -c protocol "{{ $dataDir }}/{{ $dbName }}.rdb" | redis-cli {{ if $isCluster }}-c{{end}} -h {{ $hostName }} -p {{ $port }} --pipe {{ if $sslEnabled -}}--tls{{ end }} 
+    # But surpress MOVED messages
+    rdb -c protocol "{{ $dataDir }}/{{ $dbName }}.rdb" | redis-cli {{ if $isCluster }}-c{{end}} -h {{ $hostName }} -p {{ $port }} --pipe {{ if $sslEnabled -}}--tls{{ end }} 2>&1 | grep -v MOVED
 
     {{ if not $isCluster }}
     # Start a BGSAVE so the database is backed up to disk and ready to be loaded from if necessary.
     redis-cli -h {{ $hostName }} -p {{ $port }} {{ if $sslEnabled -}}--tls{{ end }} {{ if $isCluster }}-c{{end}} BGSAVE
     {{- end }}
 
+    # Don't exit until we've had a chance to look at the logs
+    sleep 86400
+
     # Report success.
-    echo "Completed restoring {{ $dbConf.restoreURL }} into {{ $dbName }} at {{ $hostName }}:{{ $port }}."
+    # echo "Completed restoring {{ $dbConf.restoreURL }} into {{ $dbName }} at {{ $hostName }}:{{ $port }}."
 ---
 apiVersion: v1
 kind: Secret

--- a/helm/node-normalization-loader/templates/loader-pipe-job.yaml
+++ b/helm/node-normalization-loader/templates/loader-pipe-job.yaml
@@ -103,7 +103,7 @@ data:
     gunzip "{{ $dataDir }}/{{ $dbName }}.rdb.gz"
 
     # Restore the file into the specified database.
-    rdb -c protocol "{{ $dataDir }}/{{ $dbName }}.rdb" | redis-cli -h {{ $hostName }} -p {{ $port }} --pipe {{ if $sslEnabled -}}--tls{{ end }} {{ if $isCluster }}-c{{end}}
+    rdb -c protocol "{{ $dataDir }}/{{ $dbName }}.rdb" | redis-cli {{ if $isCluster }}-c{{end}} -h {{ $hostName }} -p {{ $port }} --pipe {{ if $sslEnabled -}}--tls{{ end }} 
 
     {{ if not $isCluster }}
     # Start a BGSAVE so the database is backed up to disk and ready to be loaded from if necessary.

--- a/helm/node-normalization-web-server/ncats-images-meta.yaml
+++ b/helm/node-normalization-web-server/ncats-images-meta.yaml
@@ -1,3 +1,3 @@
 nodeNormalization:
   image: ghcr.io/translatorsri/nodenormalization
-  version: v2.3.4
+  version: v2.3.3

--- a/helm/node-normalization-web-server/ncats-images-meta.yaml
+++ b/helm/node-normalization-web-server/ncats-images-meta.yaml
@@ -1,3 +1,3 @@
 nodeNormalization:
   image: ghcr.io/translatorsri/nodenormalization
-  version: v2.3.3
+  version: v2.3.4


### PR DESCRIPTION
This PR fixes several issues in the NodeNorm loader that we discovered in trying to load this data into ITRB:
- `--tls` did not have proper spacing around it because of incorrect use of `{{-`.
- When using `redis-cli` with a Redis cluster, the `-c` flag is necessary to ensure that `MOVED` and `ASK` redirects are followed. This has now been added when the `is_cluster` flag is set.
- `BGSAVE` appears to be unnecessary on the cluster, and so this is removed when the `is_cluster` flag is set.
- We get a lot of `MOVED` messages from redis-cli, so we now filter them out with a crude grep to make it easier to spot actual errors.
- The version information in nn-loader's `ncats-images-meta.yaml` file should never be used, but for completeness I have updated it to the latest version.