### PR TITLE
Reduce memory for NameRes

### DIFF
--- a/helm/name-lookup/values.yaml
+++ b/helm/name-lookup/values.yaml
@@ -63,7 +63,7 @@ solr:
     affinity:
     tolerations:
 
-  heap_mem: "-Xms32G -Xmx32G"
+  heap_mem: "-Xms34G -Xmx34G"
   gc: "-XX:NewSize=4G -XX:MaxNewSize=4G -XX:+UseG1GC -XX:MaxGCPauseMillis=1000 -XX:+UnlockExperimentalVMOptions -XX:G1MaxNewSizePercent=40 -XX:G1NewSizePercent=5 -XX:G1HeapRegionSize=32M -XX:InitiatingHeapOccupancyPercent=90"
 
   # As of Babel 2023jul13, we need 130G to store the

--- a/helm/name-lookup/values.yaml
+++ b/helm/name-lookup/values.yaml
@@ -54,16 +54,16 @@ solr:
     # the memory to Solr helps with performance.
     #
     requests:
-      memory: "58Gi"
+      memory: "35Gi"
     limits:
-      memory: "58Gi"
+      memory: "35Gi"
     # You can control the nodeSelector/affinity/tolerations settings for Solr with the following settings.
     # Other pods (web, restore, backup) are controlled via app.nodeSelector/affinity/tolerations below.
     nodeSelector:
     affinity:
     tolerations:
 
-  heap_mem: "-Xms58G -Xmx58G"
+  heap_mem: "-Xms32G -Xmx32G"
   gc: "-XX:NewSize=4G -XX:MaxNewSize=4G -XX:+UseG1GC -XX:MaxGCPauseMillis=1000 -XX:+UnlockExperimentalVMOptions -XX:G1MaxNewSizePercent=40 -XX:G1NewSizePercent=5 -XX:G1HeapRegionSize=32M -XX:InitiatingHeapOccupancyPercent=90"
 
   # As of Babel 2023jul13, we need 130G to store the


### PR DESCRIPTION
ITRB only has 35Gi available in our node group, so this reduces NameRes' memory requirement to fit.