### PR TITLE
Fix affinity values for Name Lookup and NodeNorm

### DIFF
--- a/helm/name-lookup/values.yaml
+++ b/helm/name-lookup/values.yaml
@@ -57,11 +57,12 @@ solr:
       memory: "58Gi"
     limits:
       memory: "58Gi"
-    # You can control the nodeSelector/affinity/tolerations settings for Solr with the following settings.
-    # Other pods (web, restore, backup) are controlled via app.nodeSelector/affinity/tolerations below.
-    nodeSelector:
-    affinity:
-    tolerations:
+
+  # You can control the nodeSelector/affinity/tolerations settings for Solr with the following settings.
+  # Other pods (web, restore, backup) are controlled via app.nodeSelector/affinity/tolerations below.
+  nodeSelector:
+  affinity:
+  tolerations:
 
   heap_mem: "-Xms58G -Xmx58G"
   gc: "-XX:NewSize=4G -XX:MaxNewSize=4G -XX:+UseG1GC -XX:MaxGCPauseMillis=1000 -XX:+UnlockExperimentalVMOptions -XX:G1MaxNewSizePercent=40 -XX:G1NewSizePercent=5 -XX:G1HeapRegionSize=32M -XX:InitiatingHeapOccupancyPercent=90"


### PR DESCRIPTION
They were at the wrong indentation level. This PR fixes that.