### PR TITLE
Added code to chunk blocklist deletions in NameLookup

### DIFF
--- a/helm/name-lookup/templates/restore-job.yaml
+++ b/helm/name-lookup/templates/restore-job.yaml
@@ -23,7 +23,11 @@ spec:
                   requests:
                     storage: {{ .Values.blocklist.storage }}
         {{ end }}
-      restartPolicy: OnFailure
+      # Because of the way in which the Restore Job works -- by creating fields in
+      # the Solr database, including copy fields -- it can no longer be re-run on
+      # failure. Instead, it should fail so we can look at the error output and
+      # figure out what to do next.
+      restartPolicy: Never
       containers:
         - name: restore-container
           image: "{{ .Values.busybox.image.repository }}:{{ .Values.busybox.image.tag }}"

--- a/helm/name-lookup/templates/scripts-config-map.yaml
+++ b/helm/name-lookup/templates/scripts-config-map.yaml
@@ -21,6 +21,7 @@ data:
     #!/bin/sh
 
     BLOCKLIST_DIR="/var/blocklist"
+    BLOCKLIST_CHUNK_SIZE=500
 
     # Download the Blocklist file. We do this before turning on xtrace (`set -xa`) so that we don't record
     # the GitHub authorization token in the Kubernetes logs.
@@ -174,19 +175,29 @@ data:
 
     # Delete the blocklist terms from the Solr database.
     {{ if .Values.blocklist.url }}
-    CURIE_LIST=$(xargs -I{lin} echo \\\"{lin}\\\" < ${BLOCKLIST_DIR}/blocklist.txt)
-    echo CURIEs on the Blocklist: ${CURIE_LIST}.
-    SOLR_DELETE="{
-      'delete': {
-        'query': 'curie:(${CURIE_LIST})'
-      }}"
-    echo SOLR delete query: ${SOLR_DELETE}
+    read -a CURIE_LIST <<< $(xargs -I{lin} echo \\\"{lin}\\\" < ${BLOCKLIST_DIR}/blocklist.txt)
+    echo CURIEs on the Blocklist: ${CURIE_LIST[@]}.
 
-    wget --post-data "${SOLR_DELETE}" \
-    --header='Content-Type:application/json' \
-    -O- ${SOLR_SERVER}/solr/${COLLECTION_NAME}/update?commit=true
+    # The blocklist is pretty large, so we break it into chunks.
+    arrayLength=${#CURIE_LIST[@]}
+    echo Chunking ${arrayLength} CURIEs into chunks of ${BLOCKLIST_CHUNK_SIZE}.
 
-    sleep 1
+    for ((i=0; i<${arrayLength}; i+=BLOCKLIST_CHUNK_SIZE)); do
+      # Process chunk
+      curie_chunk=("${CURIE_LIST[@]:i:BLOCKLIST_CHUNK_SIZE}")
+
+      SOLR_DELETE="{
+        'delete': {
+          'query': 'curie:(${curie_chunk[@]})'
+        }}"
+      echo SOLR delete query: ${SOLR_DELETE}
+
+      wget --post-data "${SOLR_DELETE}" \
+      --header='Content-Type:application/json' \
+      -O- ${SOLR_SERVER}/solr/${COLLECTION_NAME}/update?commit=true
+
+      sleep 10
+    done
     {{ end }}
  
     exit 0

--- a/helm/name-lookup/templates/scripts-config-map.yaml
+++ b/helm/name-lookup/templates/scripts-config-map.yaml
@@ -175,22 +175,22 @@ data:
 
     # Delete the blocklist terms from the Solr database.
     {{ if .Values.blocklist.url }}
-    read -a CURIE_LIST <<< $(xargs -I{lin} echo \\\"{lin}\\\" < ${BLOCKLIST_DIR}/blocklist.txt)
-    echo CURIEs on the Blocklist: ${CURIE_LIST[@]}.
 
-    # The blocklist is pretty large, so we break it into chunks.
-    arrayLength=${#CURIE_LIST[@]}
-    echo Chunking ${arrayLength} CURIEs into chunks of ${BLOCKLIST_CHUNK_SIZE}.
+    BLOCKLIST_DIR=/var/blocklist
 
-    for ((i=0; i<${arrayLength}; i+=BLOCKLIST_CHUNK_SIZE)); do
-      # Process chunk
-      curie_chunk=("${CURIE_LIST[@]:i:BLOCKLIST_CHUNK_SIZE}")
+    # Split the blocklist into files of 500 CURIEs each.
+    rm -rf ${BLOCKLIST_DIR}/blocklist_*
+    split -l ${BLOCKLIST_CHUNK_SIZE} ${BLOCKLIST_DIR}/blocklist.txt ${BLOCKLIST_DIR}/blocklist_
+
+    # Delete each blocklist.
+    for file in ${BLOCKLIST_DIR}/blocklist_*; do
+      CURIE_LIST=$(xargs -I{lin} echo \\\"{lin}\\\" < ${file})
 
       SOLR_DELETE="{
         'delete': {
-          'query': 'curie:(${curie_chunk[@]})'
+          'query': 'curie:(${CURIE_LIST})'
         }}"
-      echo SOLR delete query: ${SOLR_DELETE}
+      echo SOLR delete query for ${file}: ${SOLR_DELETE}
 
       wget --post-data "${SOLR_DELETE}" \
       --header='Content-Type:application/json' \

--- a/helm/name-lookup/templates/scripts-config-map.yaml
+++ b/helm/name-lookup/templates/scripts-config-map.yaml
@@ -33,6 +33,7 @@ data:
 
       CURIE_LIST=$(xargs -I{lin} echo \"{lin}\" < ${BLOCKLIST_DIR}/blocklist.txt)
       echo CURIEs on the Blocklist: ${CURIE_LIST}.
+      echo Blocklist CURIEs will be chunked into chunks of ${BLOCKLIST_CHUNK_SIZE}.
     {{ end }}
 
     # Turn on xtrace and set up config variables.

--- a/helm/name-lookup/values.yaml
+++ b/helm/name-lookup/values.yaml
@@ -115,8 +115,9 @@ blocklist:
   # in `blocklist.secrets.github_personal_access_token` in an encrypted file. You can also
   # set this on Kubernetes by running:
   #   kubectl -n $NAMESPACE create secret generic {{name-lookup.fullname}}-secrets --from-literal=github_personal_access_token=github_pat_...
-  # The storage necessary to store the blocklist file. This is currently an ephemeral volume, so make sure it fits in the
-  # ephemeral storage limit!
+  # The storage necessary to store the blocklist file. This is currently an ephemeral volume, and because we need
+  # to use `split` to split this into 500 ID chunks, we actually need TWICE the amount of storage needed to store
+  # the blocklist. Luckily, the blocklist is about 7KB right now, so 100Mi should be future proof for a while.
   storage: 100Mi
 
 x_trapi:


### PR DESCRIPTION
NameLookup downloads a blocklist and deletes those concepts from the Solr database, but the blocklist is now large enough that it cannot be deleted in less than a second. This PR modifies the blocklist code so that it carries out deletions in chunks.