### PR TITLE
Added support for explicitly setting app resources on NameLookup

### DIFF
--- a/helm/name-lookup/templates/web-deployment.yaml
+++ b/helm/name-lookup/templates/web-deployment.yaml
@@ -44,6 +44,10 @@ spec:
             - name: http
               containerPort: {{ .Values.webServer.port }}
               protocol: TCP
+          {{- with .Values.app.resources }}
+          resources:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
       {{- with .Values.app.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/helm/name-lookup/values.yaml
+++ b/helm/name-lookup/values.yaml
@@ -97,6 +97,13 @@ app:
   nodeSelector:
   affinity:
   tolerations:
+  resources:
+    requests:
+      memory: "300M"
+      cpu: 250m
+    limits:
+      memory: "512M"
+      cpu: 500m
 
 nameOverride: ""
 fullnameOverride: ""


### PR DESCRIPTION
NameLookup has been using the default resources for its web frontend. This PR allows resources to be explicitly configured for that node.