### PR TITLE
Delays deletion of the Solr directory until after download in NameLookup

### DIFF
--- a/helm/name-lookup/templates/scripts-config-map.yaml
+++ b/helm/name-lookup/templates/scripts-config-map.yaml
@@ -9,14 +9,22 @@ data:
     #!/bin/sh
     set -xa
     DATA_DIR="/var/solr/data"
+    DOWNLOAD_DIR="/var/solr/download"
     BACKUP_NAME="snapshot.backup"
     BACKUP_ZIP="${BACKUP_NAME}.tar.gz"
     BACKUP_URL="{{ .Values.dataUrl }}"
-    rm -rf $DATA_DIR/*
-    wget -nv -O $DATA_DIR/$BACKUP_ZIP $BACKUP_URL
+
+    # Delete the download directory.
+    rm -rf $DOWNLOAD_DIR
+    mkdir -p $DOWNLOAD_DIR
+    wget -nv -O $DOWNLOAD_DIR/$BACKUP_ZIP $BACKUP_URL
+
+    # Download
+    rm -rf $DATA_DIR
+    mkdir -p $DATA_DIR
     cd $DATA_DIR
-    tar -xf $DATA_DIR/$BACKUP_ZIP -C $DATA_DIR
-    rm $DATA_DIR/$BACKUP_ZIP
+    tar -xf $DOWNLOAD_DIR/$BACKUP_ZIP -C $DATA_DIR
+    rm -rf $DOWNLOAD_DIR
   restore.sh: |-
     #!/bin/sh
 

--- a/helm/name-lookup/templates/solr-deployment.yaml
+++ b/helm/name-lookup/templates/solr-deployment.yaml
@@ -29,7 +29,7 @@ spec:
           command:
             - /download.sh
           volumeMounts:
-            - mountPath: /var/solr/data
+            - mountPath: /var/solr
               name: {{ include "name-lookup.fullname" . }}-solr-data-vol
             - mountPath: "/download.sh"
               name: {{ include "name-lookup.fullname" . }}-configmap


### PR DESCRIPTION
This means that if we accidentally start a pod with LOAD_DATA=yes, we should have about an hour to re-run it with LOAD_DATA=no before the database gets deleted.

Closes #842.