### PR TITLE
NameLookup: decreased memory, increased CPUs

### DIFF
--- a/helm/name-lookup/values.yaml
+++ b/helm/name-lookup/values.yaml
@@ -54,11 +54,11 @@ solr:
     # the memory to Solr helps with performance.
     #
     requests:
-      memory: "58Gi"
+      memory: "16Gi"
       cpu: 1000m
     limits:
-      memory: "58Gi"
-      cpu: 2000m
+      memory: "32Gi"
+      cpu: 3000m
 
   # You can control the nodeSelector/affinity/tolerations settings for Solr with the following settings.
   # Other pods (web, restore, backup) are controlled via app.nodeSelector/affinity/tolerations below.


### PR DESCRIPTION
This PR reduces the memory used by NameLookup, but increases the number of CPUs it requests, which should allow it to do a better job of handling queries.