### PR TITLE
Ci cd helm build

### DIFF
--- a/.github/workflows/release-charts.yaml
+++ b/.github/workflows/release-charts.yaml
@@ -27,7 +27,7 @@ jobs:
 
     - name: Log in to  Container Registry
       run: |
-        helm registry login containers.renci.org --username ${{ secrets.CONTAINERHUB_USERNAME }} --password ${{ secrets.CONTAINERHUB_TOKEN }}
+        helm registry login containers.renci.org --username '${{ secrets.CONTAINERHUB_USERNAME }}' --password '${{ secrets.CONTAINERHUB_TOKEN }}'
 
     - name: Package and Push Charts
       run: |

--- a/.github/workflows/release-charts.yaml
+++ b/.github/workflows/release-charts.yaml
@@ -30,7 +30,7 @@ jobs:
         USERNAME: ${{ secrets.secrets.CONTAINERHUB_USERNAME }}
         TOKEN: ${{ secrets.CONTAINERHUB_TOKEN }}
       run: |
-        echo $TOKEN | helm registry login containers.renci.org --username $USERNAME --password-stdin
+        helm registry login containers.renci.org --username $USERNAME --password $TOKEN
 
     - name: Package and Push Charts
       run: |

--- a/.github/workflows/release-charts.yaml
+++ b/.github/workflows/release-charts.yaml
@@ -31,7 +31,7 @@ jobs:
 
     - name: Package and Push Charts
       run: |
-        for chart in $(ls -d charts/*/); do
+        for chart in $(ls -d helm/*/); do
           chart_name=$(basename $chart)
           version=$(yq eval '.version' $chart/Chart.yaml)
           echo "Packaging $chart_name with version $version"

--- a/.github/workflows/release-charts.yaml
+++ b/.github/workflows/release-charts.yaml
@@ -31,12 +31,27 @@ jobs:
 
     - name: Package and Push Charts
       run: |
-        for chart in $(ls -d helm/*/); do
-          chart_name=$(basename $chart)
-          version=$(yq eval '.version' $chart/Chart.yaml)
-          echo "Packaging $chart_name with version $version"
-          helm chart save $chart containers.renci.org/translator/$chart_name:$version
-          helm chart push containers.renci.org/translator/$chart_name:$version
+        set -e  # Exit immediately if any command exits with a non-zero status
+        for chart in helm/*/; do
+          if [ -f "$chart/Chart.yaml" ]; then
+            chart_name=$(basename "$chart")
+            version=$(yq eval '.version' "$chart/Chart.yaml")
+            if [ -z "$version" ]; then
+              echo "Error: Could not find version in $chart_name/Chart.yaml"
+              exit 1
+            fi
+            echo "Updating dependencies for $chart_name"
+            helm dependency update "$chart"
+
+            echo "Packaging $chart_name with version $version"
+            helm package "$chart" --version "$version" --destination ./packages
+
+            echo "Pushing $chart_name with version $version to OCI registry"
+            helm push ./packages/"$chart_name-$version.tgz" oci://containers.renci.org/translator/
+          else
+            echo "Error: Chart.yaml not found in $chart"
+            exit 1
+          fi
         done
 #
 #    - name: Create GitHub Release

--- a/.github/workflows/release-charts.yaml
+++ b/.github/workflows/release-charts.yaml
@@ -1,0 +1,50 @@
+name: Helm OCI Package and Release to GitHub Container Registry
+
+on:
+  push:
+    branches:
+      - ci-cd-helm-build
+  pull_request:
+    branches:
+      - ci-cd-helm-build
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v2
+
+    - name: Set up Helm
+      run: |
+        curl https://raw.githubusercontent.com/helm/helm/master/scripts/get-helm-3 | bash
+        helm version
+
+    - name: Install yq (YAML processor)
+      run: |
+        sudo wget https://github.com/mikefarah/yq/releases/download/v4.13.4/yq_linux_amd64 -O /usr/bin/yq
+        sudo chmod +x /usr/bin/yq
+
+    - name: Log in to GitHub Container Registry (ghcr.io)
+      env:
+        USERNAME: ${{ secrets.secrets.CONTAINERHUB_USERNAME }}
+        TOKEN: ${{ secrets.CONTAINERHUB_TOKEN }}
+      run: |
+        echo $TOKEN | helm registry login containers.renci.org --username $USERNAME --password-stdin
+
+    - name: Package and Push Charts
+      run: |
+        for chart in $(ls -d charts/*/); do
+          chart_name=$(basename $chart)
+          version=$(yq eval '.version' $chart/Chart.yaml)
+          echo "Packaging $chart_name with version $version"
+          helm chart save $chart containers.renci.org/translator/$chart_name:$version
+          helm chart push containers.renci.org/translator/$chart_name:$version
+        done
+#
+#    - name: Create GitHub Release
+#      uses: softprops/action-gh-release@v1
+#      with:
+#        body: "New Helm charts release"
+#      env:
+#        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release-charts.yaml
+++ b/.github/workflows/release-charts.yaml
@@ -3,10 +3,10 @@ name: Helm OCI Package and Release to GitHub Container Registry
 on:
   push:
     branches:
-      - ci-cd-helm-build
+      - develop
   pull_request:
     branches:
-      - ci-cd-helm-build
+      - develop
 
 jobs:
   release:

--- a/.github/workflows/release-charts.yaml
+++ b/.github/workflows/release-charts.yaml
@@ -26,11 +26,8 @@ jobs:
         sudo chmod +x /usr/bin/yq
 
     - name: Log in to  Container Registry
-      env:
-        USERNAME: ${{ secrets.CONTAINERHUB_USERNAME }}
-        TOKEN: ${{ secrets.CONTAINERHUB_TOKEN }}
       run: |
-        helm registry login containers.renci.org --username $USERNAME --password $TOKEN
+        helm registry login containers.renci.org --username ${{ secrets.CONTAINERHUB_USERNAME }} --password ${{ secrets.CONTAINERHUB_TOKEN }}
 
     - name: Package and Push Charts
       run: |

--- a/.github/workflows/release-charts.yaml
+++ b/.github/workflows/release-charts.yaml
@@ -48,8 +48,7 @@ jobs:
 
             echo "Pushing $chart_name with version $version to OCI registry"
             helm push ./packages/"$chart_name-$version.tgz" oci://containers.renci.org/translator/
-            rm ./packages/"$chart_name-$version.tgz"
-          
+            rm ./packages/"$chart_name-$version.tgz"          
         done
 #
 #    - name: Create GitHub Release

--- a/.github/workflows/release-charts.yaml
+++ b/.github/workflows/release-charts.yaml
@@ -48,7 +48,8 @@ jobs:
 
             echo "Pushing $chart_name with version $version to OCI registry"
             helm push ./packages/"$chart_name-$version.tgz" oci://containers.renci.org/translator/
-            rm ./packages/"$chart_name-$version.tgz"          
+            rm ./packages/"$chart_name-$version.tgz"
+          fi
         done
 #
 #    - name: Create GitHub Release

--- a/.github/workflows/release-charts.yaml
+++ b/.github/workflows/release-charts.yaml
@@ -25,9 +25,9 @@ jobs:
         sudo wget https://github.com/mikefarah/yq/releases/download/v4.13.4/yq_linux_amd64 -O /usr/bin/yq
         sudo chmod +x /usr/bin/yq
 
-    - name: Log in to GitHub Container Registry (ghcr.io)
+    - name: Log in to  Container Registry
       env:
-        USERNAME: ${{ secrets.secrets.CONTAINERHUB_USERNAME }}
+        USERNAME: ${{ secrets.CONTAINERHUB_USERNAME }}
         TOKEN: ${{ secrets.CONTAINERHUB_TOKEN }}
       run: |
         helm registry login containers.renci.org --username $USERNAME --password $TOKEN

--- a/.github/workflows/release-charts.yaml
+++ b/.github/workflows/release-charts.yaml
@@ -34,7 +34,7 @@ jobs:
         set -e  # Exit immediately if any command exits with a non-zero status
         for chart in helm/*/; do
           if [ -f "$chart/Chart.yaml" ]; then
-            chart_name=$(basename "$chart")
+            chart_name=$(yq eval '.name' "$chart/Chart.yaml")
             version=$(yq eval '.version' "$chart/Chart.yaml")
             if [ -z "$version" ]; then
               echo "Error: Could not find version in $chart_name/Chart.yaml"
@@ -48,6 +48,7 @@ jobs:
 
             echo "Pushing $chart_name with version $version to OCI registry"
             helm push ./packages/"$chart_name-$version.tgz" oci://containers.renci.org/translator/
+            rm ./packages/"$chart_name-$version.tgz"
           else
             echo "Error: Chart.yaml not found in $chart"
             exit 1

--- a/.github/workflows/release-charts.yaml
+++ b/.github/workflows/release-charts.yaml
@@ -49,10 +49,7 @@ jobs:
             echo "Pushing $chart_name with version $version to OCI registry"
             helm push ./packages/"$chart_name-$version.tgz" oci://containers.renci.org/translator/
             rm ./packages/"$chart_name-$version.tgz"
-          else
-            echo "Error: Chart.yaml not found in $chart"
-            exit 1
-          fi
+          
         done
 #
 #    - name: Create GitHub Release


### PR DESCRIPTION
- builds helm charts versioned by their version numbers in the Chart.yaml file
- pushes the helm packages to `containers.renci.org/translator/<chart-name>:<chart-version>`


This is mainly to address the gap with our branch to environment mapping. Where changes are not isolated perfectly per chart. And unwanted updates from develop branch making it into master. 
Using chart versions we can actually track the charts individually. 

Next steps , we would let itrb know that we are now using helm in oci registry so instead of pointing to branches in this repo they could do something like `helm install containers.renci.org/translator/aragorn:0.0.1` where we can include the chart version for each environment as part of the request. 

### Important
On our part we should actively bump chart versions, so that all the new changes we have will be pushed to containers.renci.org without overriding the previous chart. 
