### PR TITLE
Fixed NodeNorm restore URLs from 2025jan23 -> 2025mar31

### DIFF
--- a/helm/node-normalization-loader/values.yaml
+++ b/helm/node-normalization-loader/values.yaml
@@ -121,31 +121,31 @@ codeDir: /code
 
 redis_backend_config:
   "eq_id_to_id_db":
-    restoreURL: "https://stars.renci.org/var/babel_outputs/2025jan23/rdb-backups/id-id.rdb.gz"
+    restoreURL: "https://stars.renci.org/var/babel_outputs/2025mar31/rdb-backups/id-id.rdb.gz"
     storageSize: 100G
 
   "id_to_eqids_db":
-    restoreURL: "https://stars.renci.org/var/babel_outputs/2025jan23/rdb-backups/id-eq-id.rdb.gz"
+    restoreURL: "https://stars.renci.org/var/babel_outputs/2025mar31/rdb-backups/id-eq-id.rdb.gz"
     storageSize: 150G
 
   "id_to_type_db":
-    restoreURL: "https://stars.renci.org/var/babel_outputs/2025jan23/rdb-backups/id-categories.rdb.gz"
+    restoreURL: "https://stars.renci.org/var/babel_outputs/2025mar31/rdb-backups/id-categories.rdb.gz"
     storageSize: 30G
 
   "curie_to_bl_type_db":
-    restoreURL: "https://stars.renci.org/var/babel_outputs/2025jan23/rdb-backups/semantic-count.rdb.gz"
+    restoreURL: "https://stars.renci.org/var/babel_outputs/2025mar31/rdb-backups/semantic-count.rdb.gz"
     storageSize: 1G
 
   "gene_protein_db":
-    restoreURL: "https://stars.renci.org/var/babel_outputs/2025jan23/rdb-backups/conflation-db.rdb.gz"
+    restoreURL: "https://stars.renci.org/var/babel_outputs/2025mar31/rdb-backups/conflation-db.rdb.gz"
     storageSize: 10G
 
   "info_content_db":
-    restoreURL: "https://stars.renci.org/var/babel_outputs/2025jan23/rdb-backups/info-content.rdb.gz"
+    restoreURL: "https://stars.renci.org/var/babel_outputs/2025mar31/rdb-backups/info-content.rdb.gz"
     storageSize: 1G
 
   "chemical_drug_db":
-    restoreURL: "https://stars.renci.org/var/babel_outputs/2025jan23/rdb-backups/chemical-drug-db.rdb.gz"
+    restoreURL: "https://stars.renci.org/var/babel_outputs/2025mar31/rdb-backups/chemical-drug-db.rdb.gz"
     storageSize: 1G
 
 securityContext:


### PR DESCRIPTION
Made all the changes in PR #1020 except actually updating the NodeNorm restore URLs. This PR fixes that.