### PR TITLE
Fixed tag -> version in ncats-images-meta for NodeNorm Loading

### DIFF
--- a/helm/node-normalization-loader/ncats-images-meta.yaml
+++ b/helm/node-normalization-loader/ncats-images-meta.yaml
@@ -1,3 +1,3 @@
 nodeNormalizationLoader:
   image: "ghcr.io/ncatstranslator/nodenormalization-data-loading"
-  tag: "v2.3.26"
+  version: "v2.3.26"


### PR DESCRIPTION
This appears to be correct in NodeNorm Web.